### PR TITLE
API呼び出しの際にTypeを付与する仕組みの構築 #1

### DIFF
--- a/src/api/callApi.ts
+++ b/src/api/callApi.ts
@@ -1,0 +1,16 @@
+import { CreatePostRequest, CreatePostResponse, isCreatePostResponse } from './types';
+import { API } from 'aws-amplify';
+
+export const createPost = async (request: CreatePostRequest, authToken: string): Promise<CreatePostResponse | null> => {
+  const payload = {
+    headers: {
+      Authorization: authToken,
+    },
+    body: request,
+  };
+  const response = (await API.post('api', '/posts', payload)) as unknown;
+  if (isCreatePostResponse(response)) {
+    return response;
+  }
+  return null;
+};

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1,0 +1,64 @@
+import { hasProperty } from '../utils/typeUtils';
+
+export type Post = {
+  id: string;
+  userId: string;
+  timestamp: number;
+  gsiSKey: string;
+  replyId?: string;
+  lastReplyId?: string;
+  content: {
+    comment?: string;
+  };
+  reactions?: object[];
+};
+
+export type CreatePostRequest = {
+  userId: string;
+  replyId?: string;
+  content: {
+    comment?: string;
+  };
+};
+
+export type CreatePostResponse = {
+  post: Post;
+};
+
+export const isPost = (post: unknown): post is Post => {
+  if (hasProperty(post, 'id', 'userId', 'timestamp', 'gsiSKey', 'content')) {
+    if (
+      typeof post.id === 'string' &&
+      typeof post.userId === 'string' &&
+      typeof post.timestamp === 'number' &&
+      typeof post.gsiSKey === 'string'
+    ) {
+      if (post.content instanceof Object) {
+        if (hasProperty(post.content, 'comment') && typeof post.content.comment === 'string') {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
+};
+
+export const isCreatePostRequest = (request: unknown): request is CreatePostRequest => {
+  if (hasProperty(request, 'userId', 'content')) {
+    if (typeof request.userId === 'string' && request.content instanceof Object) {
+      if (hasProperty(request.content, 'comment') && typeof request.content.comment === 'string') {
+        return true;
+      }
+    }
+  }
+  return false;
+};
+
+export const isCreatePostResponse = (response: unknown): response is CreatePostResponse => {
+  if (hasProperty(response, 'post')) {
+    if (isPost(response.post)) {
+      return true;
+    }
+  }
+  return false;
+};

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -55,10 +55,8 @@ export const isCreatePostRequest = (request: unknown): request is CreatePostRequ
 };
 
 export const isCreatePostResponse = (response: unknown): response is CreatePostResponse => {
-  if (hasProperty(response, 'post')) {
-    if (isPost(response.post)) {
-      return true;
-    }
+  if (isPost(response)) {
+    return true;
   }
   return false;
 };

--- a/src/components/Test/index.tsx
+++ b/src/components/Test/index.tsx
@@ -2,6 +2,9 @@ import { Container } from '@mui/material';
 import { API } from 'aws-amplify';
 import { useAuthenticator } from '@aws-amplify/ui-react';
 
+import { CreatePostRequest } from '../../api/types';
+import { createPost } from '../../api/callApi';
+
 const Test = () => {
   const { user } = useAuthenticator((context) => [context.user]);
 
@@ -24,10 +27,38 @@ const Test = () => {
       console.error(err);
     }
   };
+
+  const callCreatePost = async () => {
+    const token = user.getSignInUserSession()?.getIdToken().getJwtToken();
+    const attr = user.attributes;
+    if (!attr || !attr.sub) return;
+    if (!token) return;
+    const d = new Date();
+    const request: CreatePostRequest = {
+      userId: attr.sub,
+      content: {
+        comment: 'test : ' + d.toISOString(),
+      },
+    };
+    try {
+      const res = await createPost(request, token);
+      console.log(res);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
   return (
     <>
       <Container maxWidth='sm'>
         <button onClick={handleClick}>click me</button>
+        <button
+          onClick={() => {
+            void callCreatePost();
+          }}
+        >
+          PostPostsAPI
+        </button>
       </Container>
     </>
   );

--- a/src/utils/typeUtils.ts
+++ b/src/utils/typeUtils.ts
@@ -1,0 +1,34 @@
+// 引数xはK[]のプロパティを持っているオブジェクトであることを示す関数
+// 持っていることを示せるが、それはunknown型
+// 型ガード関数の中で用いると便利
+// 例：
+// const isDispContent = (content: unknown): content is DispContentType => {
+//   if (
+//     hasProperty(content, 'contentId', 'title', 'dialogFlag', 'dispContentItems')
+//   ) {
+//     if (
+//       typeof content.contentId === 'string' &&
+//       typeof content.title === 'string' &&
+//       typeof content.dialogFlag === 'boolean'
+//     ) {
+//       if (content.dispContentItems instanceof Array) {
+//         return (
+//           content.dispContentItems.length === 0 ||
+//           content.dispContentItems.every(e => typeof e === 'string')
+//         );
+//       }
+//     }
+//   }
+//   return false;
+// };
+export function hasProperty<K extends string>(x: unknown, ...name: K[]): x is { [M in K]: unknown } {
+  return x instanceof Object && name.every((prop) => prop in x);
+}
+
+// 非同期関数のReturnType時にPromiseの中身を抽出する。
+// 例:
+// type ContentItemsType = PromiseType<
+//   ReturnType<typeof ContentItemService.listContentItemsByContentId>
+// >;
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type PromiseType<T extends Promise<any>> = T extends Promise<infer P> ? P : never;


### PR DESCRIPTION
close #1 
Type定義及びis関数をapi/types.tsに実装
amplify経由でAPI呼び出しを行う関数をapi/callApi.tsに実装