### PR TITLE
User作成APIの利用 #10 | 早期リターンによる制約違反の修正 #12

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,7 +3,8 @@
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
     "plugin:@typescript-eslint/recommended-requiring-type-checking",
-    "prettier"
+    "prettier",
+    "plugin:react-hooks/recommended"
   ],
   "plugins": ["@typescript-eslint"],
   "parser": "@typescript-eslint/parser",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
   "devDependencies": {
     "eslint": "^8.35.0",
     "eslint-config-prettier": "^8.6.0",
+    "eslint-plugin-react-hooks": "^4.6.0",
     "prettier": "^2.8.4"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,23 +1,18 @@
 import { Amplify } from 'aws-amplify';
 import { Authenticator } from '@aws-amplify/ui-react';
 import '@aws-amplify/ui-react/styles.css';
-import { Container } from '@mui/material';
 
 import awsExports from './aws-exports';
 import awsmobilemanual from './aws-exports-manual';
+import Top from './Top';
+
 Amplify.configure(awsExports);
 Amplify.configure(awsmobilemanual);
-
-import Test from './components/Test';
-import Home from './pages/Home';
 
 const App = () => {
   return (
     <Authenticator loginMechanisms={['username']} hideSignUp={true}>
-      <Container maxWidth='sm'>
-        <Test />
-        <Home />
-      </Container>
+      <Top />
     </Authenticator>
   );
 };

--- a/src/Top.tsx
+++ b/src/Top.tsx
@@ -1,0 +1,45 @@
+import { useState, useEffect, createContext } from 'react';
+import { useAuthenticator } from '@aws-amplify/ui-react';
+import { Container } from '@mui/material';
+
+import { CreateUserRequest, User } from './api/types/user';
+import { createUser } from './api/callApi';
+import Test from './components/Test';
+import Home from './pages/Home';
+
+const UserContext = createContext('');
+
+const Top = () => {
+  const [iuser, setIuser] = useState<User | null>();
+  const { user } = useAuthenticator((context) => [context.user]);
+  const token = user.getSignInUserSession()?.getIdToken().getJwtToken();
+  useEffect(() => {
+    void (async () => {
+      const request: CreateUserRequest = {
+        displayName: user?.username || '',
+        identity: user?.attributes?.sub || '',
+      };
+      if (!token || request.displayName === '' || request.identity === '') return;
+      try {
+        const res = await createUser(request, token);
+        if (res) {
+          setIuser(res.user);
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    })();
+  }, [token, user]);
+
+  if (!user) return <></>;
+  return (
+    <Container maxWidth='sm'>
+      <UserContext.Provider value={iuser?.id || ''}>
+        <Test />
+        <Home />
+      </UserContext.Provider>
+    </Container>
+  );
+};
+
+export default Top;

--- a/src/Top.tsx
+++ b/src/Top.tsx
@@ -7,10 +7,10 @@ import { createUser } from './api/callApi';
 import Test from './components/Test';
 import Home from './pages/Home';
 
-const UserContext = createContext('');
+const UserContext = createContext<User | null>(null);
 
 const Top = () => {
-  const [iuser, setIuser] = useState<User | null>();
+  const [iuser, setIuser] = useState<User | null>(null);
   const { user } = useAuthenticator((context) => [context.user]);
   const token = user.getSignInUserSession()?.getIdToken().getJwtToken();
   useEffect(() => {
@@ -34,7 +34,7 @@ const Top = () => {
   if (!user) return <></>;
   return (
     <Container maxWidth='sm'>
-      <UserContext.Provider value={iuser?.id || ''}>
+      <UserContext.Provider value={iuser}>
         <Test />
         <Home />
       </UserContext.Provider>

--- a/src/api/callApi.ts
+++ b/src/api/callApi.ts
@@ -6,6 +6,7 @@ import {
   isGetAllPostResponse,
 } from './types/post';
 import { API } from 'aws-amplify';
+import { CreateUserRequest, CreateUserResponse, isCreateUserResponse } from './types/user';
 
 export const createPost = async (request: CreatePostRequest, authToken: string): Promise<CreatePostResponse | null> => {
   const payload = {
@@ -30,6 +31,20 @@ export const getAllPost = async (authToken: string, userId?: string): Promise<Ge
   const path = userId ? `/posts/${userId}` : '/posts';
   const response = (await API.get('api', path, payload)) as unknown;
   if (isGetAllPostResponse(response)) {
+    return response;
+  }
+  return null;
+};
+
+export const createUser = async (request: CreateUserRequest, authToken: string): Promise<CreateUserResponse | null> => {
+  const payload = {
+    headers: {
+      Authorization: authToken,
+    },
+    body: request,
+  };
+  const response = (await API.post('api', '/users', payload)) as unknown;
+  if (isCreateUserResponse(response)) {
     return response;
   }
   return null;

--- a/src/api/callApi.ts
+++ b/src/api/callApi.ts
@@ -4,7 +4,7 @@ import {
   GetAllPostResponse,
   isCreatePostResponse,
   isGetAllPostResponse,
-} from './types';
+} from './types/post';
 import { API } from 'aws-amplify';
 
 export const createPost = async (request: CreatePostRequest, authToken: string): Promise<CreatePostResponse | null> => {

--- a/src/api/types/post.ts
+++ b/src/api/types/post.ts
@@ -1,4 +1,4 @@
-import { hasProperty } from '../utils/typeUtils';
+import { hasProperty } from '../../utils/typeUtils';
 
 export type Post = {
   id: string;

--- a/src/api/types/user.ts
+++ b/src/api/types/user.ts
@@ -1,0 +1,57 @@
+import { hasProperty } from '../../utils/typeUtils';
+
+export type User = {
+  id: string;
+  displayName: string;
+  identity: string;
+};
+
+export type PublicUser = {
+  id: string;
+  displayName: string;
+};
+
+export type CreateUserRequest = {
+  displayName: string;
+  identity: string;
+};
+
+export type CreateUserResponse = {
+  user: User;
+};
+
+export const isUser = (user: unknown): user is User => {
+  if (hasProperty(user, 'id', 'displayName', 'identity')) {
+    if (typeof user.id === 'string' && typeof user.displayName === 'string' && typeof user.identity === 'string') {
+      return true;
+    }
+  }
+  return false;
+};
+
+export const isPublicUser = (user: unknown): user is PublicUser => {
+  if (hasProperty(user, 'id', 'displayName')) {
+    if (typeof user.id === 'string' && typeof user.displayName === 'string') {
+      return true;
+    }
+  }
+  return false;
+};
+
+export const isCreateUserRequest = (request: unknown): request is CreateUserRequest => {
+  if (hasProperty(request, 'displayName', 'identity')) {
+    if (typeof request.displayName === 'string' && typeof request.identity === 'string') {
+      return true;
+    }
+  }
+  return false;
+};
+
+export const isCreateUserResponse = (response: unknown): response is CreateUserResponse => {
+  if (hasProperty(response, 'user')) {
+    if (isUser(response.user)) {
+      return true;
+    }
+  }
+  return false;
+};

--- a/src/components/Posts/EditPosts.tsx
+++ b/src/components/Posts/EditPosts.tsx
@@ -1,5 +1,5 @@
 import { useForm } from 'react-hook-form';
-import { CreatePostRequest, CreatePostResponse } from '../../api/types';
+import { CreatePostRequest, CreatePostResponse } from '../../api/types/post';
 import { createPost } from '../../api/callApi';
 import { Box, Button, TextField } from '@mui/material';
 import registerMui from '../../utils/registerMui';

--- a/src/components/Posts/TimeLine.tsx
+++ b/src/components/Posts/TimeLine.tsx
@@ -1,5 +1,5 @@
 import { List, ListItem, ListItemText } from '@mui/material';
-import { Post } from '../../api/types';
+import { Post } from '../../api/types/post';
 
 type Props = {
   posts: Post[];

--- a/src/components/Test/index.tsx
+++ b/src/components/Test/index.tsx
@@ -1,7 +1,7 @@
 import { API } from 'aws-amplify';
 import { useAuthenticator } from '@aws-amplify/ui-react';
 
-import { CreatePostRequest } from '../../api/types';
+import { CreatePostRequest } from '../../api/types/post';
 import { createPost } from '../../api/callApi';
 
 const Test = () => {

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -8,14 +8,13 @@ import EditPosts from '../../components/Posts/EditPosts';
 const Home = () => {
   const { user } = useAuthenticator((context) => [context.user]);
   const token = user.getSignInUserSession()?.getIdToken().getJwtToken();
-  if (!user.attributes || !user.attributes.sub) return <></>;
-  if (!token) return <></>;
   const [posts, setPosts] = useState<Post[]>([]);
   const [response, setResponse] = useState<CreatePostResponse | null>(null);
 
   useEffect(() => {
     void (async () => {
       try {
+        if (!token) return;
         const res = await getAllPost(token);
         if (res) {
           setPosts(res.posts);
@@ -24,7 +23,7 @@ const Home = () => {
         console.error(err);
       }
     })();
-  }, []);
+  }, [token]);
 
   useEffect(() => {
     if (!response) return;
@@ -32,6 +31,8 @@ const Home = () => {
     setPosts((prev) => [response, ...prev]);
   }, [response]);
 
+  if (!user.attributes || !user.attributes.sub) return <></>;
+  if (!token) return <></>;
   return (
     <>
       <EditPosts userId={user.attributes.sub} authToken={token} setResponse={setResponse} />

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useAuthenticator } from '@aws-amplify/ui-react';
 import { getAllPost } from '../../api/callApi';
-import { CreatePostResponse, Post } from '../../api/types';
+import { CreatePostResponse, Post } from '../../api/types/post';
 import TimeLine from '../../components/Posts/TimeLine';
 import EditPosts from '../../components/Posts/EditPosts';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7341,7 +7341,7 @@ eslint-plugin-jsx-a11y@^6.5.1:
     object.fromentries "^2.0.6"
     semver "^6.3.0"
 
-eslint-plugin-react-hooks@^4.3.0:
+eslint-plugin-react-hooks@^4.3.0, eslint-plugin-react-hooks@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.0.tgz#4c3e697ad95b77e93f8646aaa1630c1ba607edd3"
   integrity sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==


### PR DESCRIPTION
close #10 
close #12 
User作成APIをログイン時に叩く（既に作成済みなら、作成せず値が帰ってくる）
返却値をコンテキストで保持
ついでにlinterを追加。制約違反を修正