### PR TITLE
汎用情報表示用コンポーネントの作成 #18

### DIFF
--- a/src/components/CustomizedSnackbar.tsx
+++ b/src/components/CustomizedSnackbar.tsx
@@ -1,5 +1,4 @@
 import { forwardRef } from 'react';
-import Stack from '@mui/material/Stack';
 import Snackbar from '@mui/material/Snackbar';
 import MuiAlert, { AlertProps } from '@mui/material/Alert';
 
@@ -29,13 +28,11 @@ const CustomizedSnackbar = (props: Props) => {
   };
 
   return (
-    <Stack spacing={2} sx={{ width: '100%' }}>
-      <Snackbar open={open} autoHideDuration={time !== undefined ? time : 6000} onClose={handleClose}>
-        <Alert onClose={handleClose} severity={serverity} sx={{ width: '100%' }}>
-          {msg}
-        </Alert>
-      </Snackbar>
-    </Stack>
+    <Snackbar open={open} autoHideDuration={time !== undefined ? time : 6000} onClose={handleClose}>
+      <Alert onClose={handleClose} severity={serverity} sx={{ width: '100%' }}>
+        {msg}
+      </Alert>
+    </Snackbar>
   );
 };
 

--- a/src/components/CustomizedSnackbar.tsx
+++ b/src/components/CustomizedSnackbar.tsx
@@ -1,0 +1,42 @@
+import { forwardRef } from 'react';
+import Stack from '@mui/material/Stack';
+import Snackbar from '@mui/material/Snackbar';
+import MuiAlert, { AlertProps } from '@mui/material/Alert';
+
+const Alert = forwardRef<HTMLDivElement, AlertProps>(function Alert(props, ref) {
+  return <MuiAlert elevation={6} ref={ref} variant='filled' {...props} />;
+});
+
+export type Serverity = 'info' | 'success' | 'error' | 'warning';
+
+type Props = {
+  msg: string;
+  serverity: Serverity;
+  open: boolean;
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  time?: number;
+};
+
+const CustomizedSnackbar = (props: Props) => {
+  const { msg, serverity, open, setOpen, time } = props;
+
+  const handleClose = (_event?: React.SyntheticEvent | Event, reason?: string) => {
+    if (reason === 'clickaway') {
+      return;
+    }
+
+    setOpen(false);
+  };
+
+  return (
+    <Stack spacing={2} sx={{ width: '100%' }}>
+      <Snackbar open={open} autoHideDuration={time !== undefined ? time : 6000} onClose={handleClose}>
+        <Alert onClose={handleClose} severity={serverity} sx={{ width: '100%' }}>
+          {msg}
+        </Alert>
+      </Snackbar>
+    </Stack>
+  );
+};
+
+export default CustomizedSnackbar;

--- a/src/components/Test/index.tsx
+++ b/src/components/Test/index.tsx
@@ -1,11 +1,14 @@
+import { useState } from 'react';
 import { API } from 'aws-amplify';
 import { useAuthenticator } from '@aws-amplify/ui-react';
 
 import { CreatePostRequest } from '../../api/types/post';
 import { createPost } from '../../api/callApi';
+import CustomizedSnackbar from '../CustomizedSnackbar';
 
 const Test = () => {
   const { user, signOut } = useAuthenticator((context) => [context.user]);
+  const [open, setOpen] = useState<boolean>(false);
 
   const handleClick = () => {
     void apiCall();
@@ -47,6 +50,10 @@ const Test = () => {
     }
   };
 
+  const onSnapBar = () => {
+    setOpen(true);
+  };
+
   return (
     <>
       <button onClick={handleClick}>click me</button>
@@ -64,6 +71,14 @@ const Test = () => {
       >
         signOut
       </button>
+      <button
+        onClick={() => {
+          onSnapBar();
+        }}
+      >
+        newSnap
+      </button>
+      <CustomizedSnackbar msg='tst' serverity='success' open={open} setOpen={setOpen} />
     </>
   );
 };


### PR DESCRIPTION
close #18 
snapbarによる情報表示コンポーネントを作成した
なお、複数表示に対応していないため、コントロール処理が必要
今回は各々利用するコンポーネントがコントロール処理を行う（本当はコンテキスト処理で、情報を積み上げたり削除したりできるのが望ましいが時間と効果の関係から見送り）