### PR TITLE
idではなくユーザ表示名を表示する #15

### DIFF
--- a/src/Top.tsx
+++ b/src/Top.tsx
@@ -2,17 +2,20 @@ import { useState, useEffect, createContext } from 'react';
 import { useAuthenticator } from '@aws-amplify/ui-react';
 import { Container } from '@mui/material';
 
-import { CreateUserRequest, User } from './api/types/user';
-import { createUser } from './api/callApi';
+import { CreateUserRequest, PublicUser, User } from './api/types/user';
+import { createUser, getAllPublicUser } from './api/callApi';
 import Test from './components/Test';
 import Home from './pages/Home';
 
 export const UserContext = createContext<User | null>(null);
+export const UsersMapContext = createContext<Map<string, PublicUser> | null>(null);
 
 const Top = () => {
   const [iuser, setIuser] = useState<User | null>(null);
+  const [usersMap, setUsersMap] = useState<Map<string, PublicUser> | null>(null);
   const { user } = useAuthenticator((context) => [context.user]);
   const token = user.getSignInUserSession()?.getIdToken().getJwtToken();
+
   useEffect(() => {
     void (async () => {
       const request: CreateUserRequest = {
@@ -31,12 +34,32 @@ const Top = () => {
     })();
   }, [token, user]);
 
+  useEffect(() => {
+    void (async () => {
+      if (!token) return;
+      try {
+        const res = await getAllPublicUser(token);
+        if (res) {
+          const map = new Map<string, PublicUser>();
+          res.users.forEach((u) => {
+            map.set(u.id, u);
+          });
+          setUsersMap(map);
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    })();
+  }, [token]);
+
   if (!user) return <></>;
   return (
     <Container maxWidth='sm'>
       <UserContext.Provider value={iuser}>
-        <Test />
-        <Home />
+        <UsersMapContext.Provider value={usersMap}>
+          <Test />
+          <Home />
+        </UsersMapContext.Provider>
       </UserContext.Provider>
     </Container>
   );

--- a/src/api/callApi.ts
+++ b/src/api/callApi.ts
@@ -5,6 +5,7 @@ import {
   isCreatePostResponse,
   isGetAllPostResponse,
 } from './types/post';
+import { GetAllUsersResponse, isGetAllUsersResponse } from './types/user';
 import { API } from 'aws-amplify';
 import { CreateUserRequest, CreateUserResponse, isCreateUserResponse } from './types/user';
 
@@ -45,6 +46,19 @@ export const createUser = async (request: CreateUserRequest, authToken: string):
   };
   const response = (await API.post('api', '/users', payload)) as unknown;
   if (isCreateUserResponse(response)) {
+    return response;
+  }
+  return null;
+};
+
+export const getAllPublicUser = async (authToken: string): Promise<GetAllUsersResponse | null> => {
+  const payload = {
+    headers: {
+      Authorization: authToken,
+    },
+  };
+  const response = (await API.get('api', '/users', payload)) as unknown;
+  if (isGetAllUsersResponse(response)) {
     return response;
   }
   return null;

--- a/src/api/types/user.ts
+++ b/src/api/types/user.ts
@@ -20,6 +20,10 @@ export type CreateUserResponse = {
   user: User;
 };
 
+export type GetAllUsersResponse = {
+  users: PublicUser[];
+};
+
 export const isUser = (user: unknown): user is User => {
   if (hasProperty(user, 'id', 'displayName', 'identity')) {
     if (typeof user.id === 'string' && typeof user.displayName === 'string' && typeof user.identity === 'string') {
@@ -51,6 +55,17 @@ export const isCreateUserResponse = (response: unknown): response is CreateUserR
   if (hasProperty(response, 'user')) {
     if (isUser(response.user)) {
       return true;
+    }
+  }
+  return false;
+};
+
+export const isGetAllUsersResponse = (response: unknown): response is GetAllUsersResponse => {
+  if (hasProperty(response, 'users')) {
+    if (Array.isArray(response.users)) {
+      if (response.users.every((user) => isPublicUser(user))) {
+        return true;
+      }
     }
   }
   return false;

--- a/src/components/Posts/TimeLine.tsx
+++ b/src/components/Posts/TimeLine.tsx
@@ -1,21 +1,42 @@
+import { useEffect } from 'react';
 import { List, ListItem, ListItemText } from '@mui/material';
+
+import { PublicUser } from '../../api/types/user';
 import { Post } from '../../api/types/post';
 
 type Props = {
   posts: Post[];
+  users: Map<string, PublicUser> | null;
+  setUnknownUser: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
-const viewPost = (post: Post) => {
+const viewPost = (post: Post, userName: string) => {
   return (
     <ListItem key={post.id}>
-      <ListItemText primary={post.content.comment} secondary={post.userId} />
+      <ListItemText primary={post.content.comment} secondary={userName} />
     </ListItem>
   );
 };
 
 const TimeLine = (props: Props) => {
-  const { posts } = props;
-  return <List>{posts.map((post) => viewPost(post))}</List>;
+  const { posts, users, setUnknownUser } = props;
+  useEffect(() => {
+    if (!users) return;
+    const unknownUsers = posts.filter((post) => !users.get(post.userId));
+    if (unknownUsers.length > 0) {
+      setUnknownUser(true);
+    }
+  }, [users, posts, setUnknownUser]);
+
+  return (
+    <List>
+      {posts.map((post) => {
+        const user = users?.get(post.userId);
+        const userName = user?.displayName || 'Unknown User';
+        return viewPost(post, userName);
+      })}
+    </List>
+  );
 };
 
 export default TimeLine;

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -4,7 +4,8 @@ import { getAllPost } from '../../api/callApi';
 import { CreatePostResponse, Post } from '../../api/types/post';
 import TimeLine from '../../components/Posts/TimeLine';
 import EditPosts from '../../components/Posts/EditPosts';
-import { UserContext } from '../../Top';
+import { UserContext, UsersMapContext } from '../../Top';
+import CustomizedSnackbar from '../../components/CustomizedSnackbar';
 
 const Home = () => {
   const token = useAuthenticator((context) => [context.user])
@@ -12,8 +13,10 @@ const Home = () => {
     ?.getIdToken()
     .getJwtToken();
   const user = useContext(UserContext);
+  const usersMap = useContext(UsersMapContext);
   const [posts, setPosts] = useState<Post[]>([]);
   const [response, setResponse] = useState<CreatePostResponse | null>(null);
+  const [unknownUser, setUnknownUser] = useState(false);
 
   useEffect(() => {
     void (async () => {
@@ -38,7 +41,13 @@ const Home = () => {
   return (
     <>
       <EditPosts userId={user.id} authToken={token} setResponse={setResponse} />
-      <TimeLine posts={posts} />
+      <TimeLine posts={posts} users={usersMap} setUnknownUser={setUnknownUser} />
+      <CustomizedSnackbar
+        msg={'リロードしてユーザ情報を更新してください'}
+        serverity={'warning'}
+        open={unknownUser}
+        setOpen={setUnknownUser}
+      />
     </>
   );
 };


### PR DESCRIPTION
close #15 
ログイン時にユーザ名情報を取得し、表示する際にはそれを参照する
ログイン時に情報を取得した後に存在しない場合について、リロードを促す警告を表示する
これはユーザ名情報をログイン時にのみ取得しているためである。